### PR TITLE
Update BasicTokenSender.sol

### DIFF
--- a/src/BasicTokenSender.sol
+++ b/src/BasicTokenSender.sol
@@ -51,7 +51,7 @@ contract BasicTokenSender is Withdraw {
             "Maximum 5 different tokens can be sent per CCIP Message"
         );
 
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             IERC20(tokensToSendDetails[i].token).transferFrom(
                 msg.sender,
                 address(this),


### PR DESCRIPTION
Well, there's no need of initializing some 'uint256' variable to 0 because by default all 'uint' variables have a value equal to 0