### PR TITLE
Fix errors in README.md execution commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ forge script ./script/Faucet.s.sol -vvv --broadcast --rpc-url ethereumSepolia --
 Or if you want to mint 10\*\*18 units of `CCIP-BnM` test token on Avalanche Fuji, run:
 
 ```shell
-forge script ./script/Faucet.s.sol -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/Faucet.s.sol -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 ### Example 1 - Transfer Tokens from EOA to EOA
@@ -167,7 +167,7 @@ function run(
 For example, if you want to send 0.0000000000000001 CCIP-BnM from Avalanche Fuji to Ethereum Sepolia and to pay for CCIP fees in LINK, run:
 
 ```shell
-forge script ./script/Example01.s.sol -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8,uint8,address,address,uint256,uint8)" -- 2 0 <RECEIVER_ADDRESS> 0xD21341536c5cF5EB1bcb58f6723cE26e8D8E90e4 100 1
+forge script ./script/Example01.s.sol -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8,uint8,address,address,uint256,uint8)" -- 1 0 <RECEIVER_ADDRESS> 0xD21341536c5cF5EB1bcb58f6723cE26e8D8E90e4 100 1
 ```
 
 ### Example 2 - Transfer Tokens from EOA to Smart Contract
@@ -202,7 +202,7 @@ function run(
 For example, if you want to send 0.0000000000000001 CCIP-BnM from Avalanche Fuji to Ethereum Sepolia and to pay for CCIP fees in native coin (Test AVAX), run:
 
 ```shell
-forge script ./script/Example02.s.sol:CCIPTokenTransfer -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8,uint8,address,address,uint256,uint8)" -- 2 0 <BASIC_MESSAGE_RECEIVER_ADDRESS> 0xD21341536c5cF5EB1bcb58f6723cE26e8D8E90e4 100 0
+forge script ./script/Example02.s.sol:CCIPTokenTransfer -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8,uint8,address,address,uint256,uint8)" -- 1 0 <BASIC_MESSAGE_RECEIVER_ADDRESS> 0xD21341536c5cF5EB1bcb58f6723cE26e8D8E90e4 100 0
 ```
 
 3. Once the CCIP message is finalized on the destination blockchain, you can see the details about the latest message using the `script/Example02.s.sol:GetLatestMessageDetails` smart contract:
@@ -238,7 +238,7 @@ function run(SupportedNetworks source) external;
 For example, if you want to send tokens from Avalanche Fuji to Ethereum Sepolia, run:
 
 ```shell
-forge script ./script/Example03.s.sol:DeployBasicTokenSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/Example03.s.sol:DeployBasicTokenSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 2. [OPTIONAL] If you want to send tokens to the smart contract, instead of EOA, you will need to deploy [`BasicMessageReceiver.sol`](./src/BasicMessageReceiver.sol) to the **destination blockchain**. For this purpose, you can reuse the `script/Example02.s.sol:DeployBasicMessageReceiver` smart contract from the previous example:
@@ -320,7 +320,7 @@ function run(SupportedNetworks network) external;
 For example, if you want to send a message from Avalanche Fuji to Ethereum Sepolia type:
 
 ```shell
-forge script ./script/Example04.s.sol:DeployProgrammableTokenTransfers -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/Example04.s.sol:DeployProgrammableTokenTransfers -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 2. Open Metamask and fund your contract with Native tokens. For example, if you want to send a message from Avalanche Fuji to Ethereum Sepolia, you can send 0.1 Fuji AVAX to your contract. You can also do the same thing using the `cast send` command:
@@ -383,7 +383,7 @@ function run(SupportedNetworks source) external;
 For example, if you want to send a simple cross-chain message from Avalanche Fuji, run:
 
 ```shell
-forge script ./script/Example05.s.sol:DeployBasicMessageSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/Example05.s.sol:DeployBasicMessageSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 2. Fund the [`BasicMessageSender.sol`](./src/BasicMessageSender.sol) smart contract with Native Coins, either manually using your wallet or by using the `cast send` command. For example, if you want to send 0.1 Fuji AVAX, run:
@@ -455,7 +455,7 @@ function run(SupportedNetworks source) external;
 For example, if you want to send a simple cross-chain message from Avalanche Fuji, run:
 
 ```shell
-forge script ./script/Example05.s.sol:DeployBasicMessageSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/Example05.s.sol:DeployBasicMessageSender -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 2. Fund the [`BasicMessageSender.sol`](./src/BasicMessageSender.sol) smart contract with Testnet LINKs, either manually using your wallet or by using the `cast send` command. For example, if you want to send 1 Fuji LINK, run:
@@ -557,7 +557,7 @@ function run(SupportedNetworks source) external;
 For example, if you want to mint NFTs on Ethereum Sepolia from Avalanche Fuji, run:
 
 ```shell
-forge script ./script/CrossChainNFT.s.sol:DeploySource -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 2
+forge script ./script/CrossChainNFT.s.sol:DeploySource -vvv --broadcast --rpc-url avalancheFuji --sig "run(uint8)" -- 1
 ```
 
 3. Fund the [`SourceMinter.sol`](./src/cross-chain-nft-minter/SourceMinter.sol) smart contract with tokens for CCIP fees.


### PR DESCRIPTION
I am a participant in the Mandarin-CCIP-Bootcamp, and Frank recommended this project to us yesterday. While using it as per the README, I noticed a small but impactful issue.

In `Helper.sol`, `AVALANCHE_FUJI` is defined as 1, but the README incorrectly states it as 2. This discrepancy causes commands to run on `ARBITRUM_SEPOLIA` instead of `AVALANCHE_FUJI`.

Since I only set up `ETHEREUM_SEPOLIA_RPC_URL` and `AVALANCHE_FUJI_RPC_URL`, the error messages were minimal. I only discovered the issue after checking the parameters of the `run` function.