### PR TITLE
Update to CCIP 2.0 beta, CrossChainToken, and FinalityCodec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,9 @@
 [submodule "lib/openzeppelin-contracts-4.8.3"]
 	path = lib/openzeppelin-contracts-4.8.3
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib/chainlink-ccip"]
-	path = lib/chainlink-ccip
-	url = https://github.com/smartcontractkit/chainlink-ccip
-	branch = develop
 [submodule "lib/chainlink-ace"]
 	path = lib/chainlink-ace
 	url = https://github.com/smartcontractkit/chainlink-ace
+[submodule "lib/chainlink-ccip"]
+	path = lib/chainlink-ccip
+	url = https://github.com/smartcontractkit/chainlink-ccip

--- a/book/src/examples/example01-token-transfer-faster-than-finality.md
+++ b/book/src/examples/example01-token-transfer-faster-than-finality.md
@@ -7,7 +7,8 @@ Script path: `script/examples/Example01.s.sol`
 ## What You Will Do
 
 1. Mint 1 CCIP-BnM token to your EOA with `script/Faucet.s.sol`.
-2. Send that token from source chain to destination chain with `script/examples/Example01.s.sol`.
+2. (Optional) Read the executor allowed finality config (`FinalityCodec` `bytes4`) on the source chain.
+3. Send that token from source chain to destination chain with `script/examples/Example01.s.sol`.
 
 ## Before You Start
 
@@ -38,20 +39,19 @@ forge script script/Faucet.s.sol:Faucet \
   <CCIP_BNM_SOURCE_TOKEN_ADDRESS>
 ```
 
-## Step 2: (Optional) Check Executor Minimum Block Confirmations
+## Step 2: (Optional) Check Executor Allowed Finality
 
-Before picking a block depth for Faster Than Finality, you can verify the executor minimum:
+Before choosing a Faster Than Finality depth in `ExtraArgsV3`, you can read what finality modes the **Executor** allows. The on-chain API is **`getAllowedFinalityConfig() → bytes4`**, encoded with **`FinalityCodec`** (same family of values as `requestedFinalityConfig` in your message’s ExtraArgs).
 
-```ts
-import {Executor} from "@chainlink/contracts-ccip/contracts/executor/Executor.sol";
-Executor executor = Executor(EXECUTOR_ADDRESS);
-console2.log("Min block confirmations", executor.getMinBlockConfirmations());
+From a shell (replace RPC and address):
+
+```bash
+cast call <EXECUTOR_ADDRESS> "getAllowedFinalityConfig()(bytes4)" --rpc-url <SOURCE_CHAIN_RPC_URL>
 ```
 
 Why this matters:
 
-- If your requested `blockConfirmations` is below executor minimum, the send can revert.
-- If your requested `blockConfirmations` is greater than chain finality, default finality is used.
+- Your requested finality (derived from `blockConfirmations` in `EncodeExtraArgsOffchain` / `Example01` via **`FinalityCodec._encodeBlockDepth`**) must be **permitted** by the executor’s dynamic config; otherwise the send can revert.
 
 ## Step 3: Send Token With Faster Than Finality
 
@@ -77,7 +77,7 @@ Parameter notes:
 
 - `<AMOUNT>`: token amount in token decimals (for 18 decimals, `1e18` is 1 token).
 - `<GAS_LIMIT>`: set to `0` for token-only transfer to an EOA receiver.
-- `<BLOCK_CONFIRMATIONS_GT_ZERO>`: must be `> 0` in this Faster Than Finality example.
+- `<BLOCK_CONFIRMATIONS_GT_ZERO>`: must be `> 0` in this Faster Than Finality example; pick a depth consistent with the executor’s allowed finality from Step 2 and lane policy.
 - `<FEE_TOKEN_ADDRESS>`: Pass the LINK token address on the source chain here. If you want to pay for CCIP fees in native coin instead, pass `0x0000000000000000000000000000000000000000`
 
 ## Verify Result

--- a/book/src/examples/example02-hello-world-to-basic-message-receiver.md
+++ b/book/src/examples/example02-hello-world-to-basic-message-receiver.md
@@ -52,7 +52,7 @@ As a convenience, applications generally inherited `CCIPReceiver.sol` and implem
 
 ### CCIP v2.0
 
-In v2.0, receivers expose Cross Chain Verifiers and finality requirements via `getCCVsAndMinBlockDepth`:
+In v2.0, receivers expose Cross Chain Verifiers and finality requirements via `getCCVsAndFinalityConfig` (encoded with `FinalityCodec` as `bytes4 allowedFinalityConfig`):
 
 ```ts
 // SPDX-License-Identifier: MIT
@@ -65,7 +65,7 @@ interface IAny2EVMMessageReceiverV2 {
     Client.Any2EVMMessage calldata message
   ) external;
 
-  function getCCVsAndMinBlockDepth(
+  function getCCVsAndFinalityConfig(
     uint64 sourceChainSelector,
     bytes calldata sender
   )
@@ -75,7 +75,7 @@ interface IAny2EVMMessageReceiverV2 {
       address[] memory requiredCCVs,
       address[] memory optionalCCVs,
       uint8 optionalThreshold,
-      uint16 minBlockDepth
+      bytes4 allowedFinalityConfig
     );
 }
 ```
@@ -83,15 +83,11 @@ interface IAny2EVMMessageReceiverV2 {
 The receiver controls two independent dimensions:
 
 - `requiredCCVs` and `optionalCCVs` define additional verifiers required for acceptance.
-- `minBlockDepth` defines minimum block depth for Faster Than Finality execution.
-- `minBlockDepth = 0` means default finality is required.
+- `allowedFinalityConfig` defines which requested finality modes are accepted (see `FinalityCodec` in chainlink-ccip). A zero value (`WAIT_FOR_FINALITY_FLAG`) means only fully finalized messages are accepted.
 
-You can combine these independently:
+You can combine these independently (for example, add verifiers while requiring full finality, or allow faster-than-finality modes when policy allows).
 
-- Add additional verifiers while keeping `minBlockDepth = 0`.
-- Use default verifiers only, while setting `minBlockDepth > 0`.
-
-In this starter kit, `src/BasicMessageReceiverWithCCVs.sol` adds configurable verifier sets and configurable minimum block depth.
+In this starter kit, `src/BasicMessageReceiverWithCCVs.sol` adds configurable verifier sets and stores a per-chain minimum block depth, which it exposes via `FinalityCodec._encodeBlockDepth` in `getCCVsAndFinalityConfig`.
 
 ## Step 1: Deploy `BasicMessageReceiverWithCCVs` on Destination Chain
 

--- a/book/src/examples/example03-programmable-token-transfer-data-and-token.md
+++ b/book/src/examples/example03-programmable-token-transfer-data-and-token.md
@@ -64,6 +64,8 @@ This chapter uses Faster Than Finality (`blockConfirmations > 0`), so destinatio
 >
 > For this chapter (which sends Faster Than Finality), use `<MIN_BLOCK_DEPTH> > 0`.
 >
+> The script argument accepts `<MIN_BLOCK_DEPTH>` (a `uint16` passed to `BasicMessageReceiverWithCCVs.setMinBlockDepth`). On-chain, the receiver does not return that integer directly to CCIP: `getCCVsAndFinalityConfig` sets `allowedFinalityConfig` to `FinalityCodec._encodeBlockDepth(minBlockDepth)` — the same `bytes4` finality encoding CCIP 2.0 uses elsewhere for allowed finality (depth `0` means wait for full/default finality).
+>
 > Save the receiver address from the `[RESULT]` log and use it in Step 2 below.
 
 ## Step 1: Get 1 CCIP-BnM Token on Fuji
@@ -101,7 +103,7 @@ Parameter notes:
 - `<AMOUNT>` uses token decimals (`1e18` is 1 token for 18-decimal tokens).
 - `<GAS_LIMIT>` must be `> 0` because the receiver contract callback handles data.
 - `<BLOCK_CONFIRMATIONS_GT_ZERO>` must be `> 0` for Faster Than Finality.
-- `<BLOCK_CONFIRMATIONS_GT_ZERO>` should be greater than or equal to `<MIN_BLOCK_DEPTH>`.
+- `<BLOCK_CONFIRMATIONS_GT_ZERO>` should be greater than or equal to `<MIN_BLOCK_DEPTH>` (the depth you stored on the receiver; CCIP compares it against your message’s `requestedFinalityConfig` after both sides use `FinalityCodec` encoding).
 - Executor may enforce a minimum block confirmation value and revert if too low.
 - If requested confirmations exceed chain finality, default finality is used.
 - `<FEE_TOKEN_ADDRESS>`: Pass the LINK token address on the source chain here. If you want to pay for CCIP fees in native coin instead, pass `0x0000000000000000000000000000000000000000`

--- a/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
+++ b/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
@@ -70,10 +70,10 @@ Script path: `script/examples/Example05.s.sol`
 
 The `ExtraArgsV3` is a structured set of delivery/execution options encoded and attached to a CCIP message.
 
-```c++
+```solidity
 struct GenericExtraArgsV3 {
     uint32 gasLimit;
-    uint16 blockConfirmations;
+    bytes4 requestedFinalityConfig;
     address[] ccvs;
     bytes[] ccvArgs;
     address executor;
@@ -83,8 +83,10 @@ struct GenericExtraArgsV3 {
 }
 ```
 
+(On-chain this struct lives in `ExtraArgsCodec` from `@chainlink/contracts-ccip`.)
+
 - `gasLimit`: gas allocated for callback execution on destination. If `0` and message data is empty, no callback executes.
-- `blockConfirmations`: confirmation depth before execution. `0` means default finality for the lane.
+- `requestedFinalityConfig`: `bytes4` finality mode + parameters per `FinalityCodec` (not a bare `uint16`). All-zero means wait for default/lane finality. For block-depth style faster-than-finality, encode with `FinalityCodec._encodeBlockDepth(uint16)` (see CCIP / `FinalityCodec` NatSpec). **Example05** and `EncodeExtraArgsOffchain.encodeV3` / `encodeV3Basic` take a `blockConfirmations` argument only as a convenience and set this field to `FinalityCodec._encodeBlockDepth(blockConfirmations)`.
 - `ccvs`: list of cross-chain verifier addresses. Empty means default verifiers.
 - `ccvArgs`: optional arguments for each CCV. Must match `ccvs` length.
 - `executor`: executor address on source chain. `address(0)` uses default executor.

--- a/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
+++ b/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
@@ -95,6 +95,7 @@ struct GenericExtraArgsV3 {
 Related helpers in `script/EncodeExtraArgsOffchain.s.sol`:
 
 - `encodeV3Basic(gasLimit, blockConfirmations)` for a minimal V3 payload.
+- `encodeAllowedFinalityBlockDepthAndSafeFlag(blockDepth)` exposes `FinalityCodec._encodeBlockDepthAndSafeFlag` — use for **allowed** finality (`bytes4`) on pools/receivers/executor policy, **not** as `requestedFinalityConfig` in sender ExtraArgs (see `FinalityCodec` NatSpec: safe+depth is only valid for allowed finality).
 - `getNoExecutionAddress()` returns `Client.NO_EXECUTION_ADDRESS` for manual execution path.
 
 ## Step 1: Send Message With No-Execution-Tag

--- a/book/src/examples/example06-cct01-burnmint-token-and-pool-setup.md
+++ b/book/src/examples/example06-cct01-burnmint-token-and-pool-setup.md
@@ -2,7 +2,7 @@
 
 This example covers the full BurnMint CCT flow on Fuji -> Sepolia:
 
-1. Deploy BurnMint token + BurnMint pool on both chains.
+1. Deploy [`CrossChainToken`](https://github.com/smartcontractkit/chainlink-ccip/blob/develop/chains/evm/contracts/tokens/CrossChainToken.sol) + BurnMint pool on both chains.
 2. Configure pools to trust each other.
 3. Send a token transfer across the lane.
 4. Verify BurnMint behavior (burn on source, mint on destination).
@@ -30,13 +30,16 @@ Scripts used:
 
 ## Script Defaults
 
-`DeployCCTBurnMintTokenAndPool` deploys token with:
+`DeployCCTBurnMintTokenAndPool` deploys a **CrossChainToken** (via `BaseERC20.ConstructorParams`) with:
 
 - `name`: `TestToken`
 - `symbol`: `TEST`
 - `decimals`: `18`
 - `preMint`: `1_000_000 * 1e18`
 - `maxSupply`: `100_000_000 * 1e18`
+- `preMintRecipient`, `ccipAdmin`, burn/mint role admin, and AccessControl owner: the broadcasting EOA
+
+Token admin registration uses `RegistryModuleOwnerCustom.registerAdminViaGetCCIPAdmin` (CrossChainToken exposes `getCCIPAdmin()` from `BaseERC20`, not `owner()`).
 
 The deployment also uses:
 

--- a/book/src/examples/example07-cct02-lockrelease-token-and-pool-setup.md
+++ b/book/src/examples/example07-cct02-lockrelease-token-and-pool-setup.md
@@ -32,13 +32,15 @@ Scripts used:
 
 ## Script Defaults
 
-`DeployCCTLockReleaseTokenAndPool` deploys token with:
+`DeployCCTLockReleaseTokenAndPool` deploys a **CrossChainToken** (same defaults as Example 06) for the underlying ERC-20, with:
 
 - `name`: `TestToken`
 - `symbol`: `TEST`
 - `decimals`: `18`
 - `preMint`: `1_000_000 * 1e18`
 - `maxSupply`: `100_000_000 * 1e18`
+
+Admin registration uses `registerAdminViaGetCCIPAdmin` on the token (see Example 06).
 
 The deployment also uses:
 

--- a/book/src/examples/example08-cct03-burnmint-with-advanced-pool-hooks.md
+++ b/book/src/examples/example08-cct03-burnmint-with-advanced-pool-hooks.md
@@ -27,7 +27,7 @@ This flow still demonstrates the correct hook wiring pattern for ACE-enabled set
 
 ## What This Example Covers
 
-1. Deploy BurnMint token + `AdvancedPoolHooks` + BurnMint pool on both chains.
+1. Deploy CrossChainToken + `AdvancedPoolHooks` + BurnMint pool on both chains.
 2. Configure pools to trust each other.
 3. Send token transfer with the existing ExtraArgsV3 default-finality sender.
 4. Verify hook attachment and allowlist settings.
@@ -55,7 +55,7 @@ Scripts used:
 
 ## Script Defaults
 
-`DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook` deploys token with:
+`DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook` deploys **CrossChainToken** with the same token defaults as Example 06 (`BaseERC20.ConstructorParams` + `registerAdminViaGetCCIPAdmin`):
 
 - `name`: `TestToken`
 - `symbol`: `TEST`

--- a/book/src/tools/ccip-sdk-ccip-send.md
+++ b/book/src/tools/ccip-sdk-ccip-send.md
@@ -22,14 +22,14 @@ When using `--block-confirmations > 0` (Faster Than Finality), receiver compatib
 
 | Mode | `--block-confirmations 0` | `--block-confirmations > 0` |
 |---|---|---|
-| `data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
-| `token-data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
+| `data` | baseline receiver works | destination receiver must allow the requested finality (see `getCCVsAndFinalityConfig` / `allowedFinalityConfig`) |
+| `token-data` | baseline receiver works | destination receiver must allow the requested finality (see `getCCVsAndFinalityConfig` / `allowedFinalityConfig`) |
 | `token` with `--gas-limit 0` | callback not executed (EOA-style token receive path) | callback not executed (EOA-style token receive path) |
 
 Terminology note:
 
-- Sender side (`ExtraArgsV3`): `blockConfirmations`
-- Receiver side (`getCCVsAndMinBlockDepth`): `minBlockDepth`
+- Sender side (`ExtraArgsV3`): requested finality (e.g. `FinalityCodec` / block depth in `requestedFinalityConfig`)
+- Receiver side (`getCCVsAndFinalityConfig`): `allowedFinalityConfig` (`bytes4`, `FinalityCodec`)
 
 ## How This Script Uses the SDK
 

--- a/foundry.lock
+++ b/foundry.lock
@@ -6,10 +6,7 @@
     }
   },
   "lib/chainlink-ccip": {
-    "branch": {
-      "name": "develop",
-      "rev": "acc1ef3c1e3c7d286e9da9036bcebc33b2239f05"
-    }
+    "rev": "3490f129337aa14c9c90786c244416d3fb9f79ed"
   },
   "lib/chainlink-evm": {
     "tag": {

--- a/script/EncodeExtraArgsOffchain.s.sol
+++ b/script/EncodeExtraArgsOffchain.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 import {ExtraArgsCodec} from "@chainlink/contracts-ccip/contracts/libraries/ExtraArgsCodec.sol";
+import {FinalityCodec} from "@chainlink/contracts-ccip/contracts/libraries/FinalityCodec.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
@@ -79,7 +80,7 @@ contract EncodeExtraArgsOffchain {
     ) public pure returns (bytes memory extraArgsBytes) {
         ExtraArgsCodec.GenericExtraArgsV3 memory extraArgs = ExtraArgsCodec.GenericExtraArgsV3({
             gasLimit: gasLimit,
-            blockConfirmations: blockConfirmations,
+            requestedFinalityConfig: FinalityCodec._encodeBlockDepth(blockConfirmations),
             ccvs: ccvs,
             ccvArgs: ccvArgs,
             executor: executor,
@@ -97,7 +98,8 @@ contract EncodeExtraArgsOffchain {
         pure
         returns (bytes memory extraArgsBytes)
     {
-        extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, blockConfirmations);
+        bytes4 finalityConfig = FinalityCodec._encodeBlockDepth(blockConfirmations);
+        extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, finalityConfig);
     }
 
     /// @notice Get the NO_EXECUTION_ADDRESS for manual execution.

--- a/script/EncodeExtraArgsOffchain.s.sol
+++ b/script/EncodeExtraArgsOffchain.s.sol
@@ -102,6 +102,13 @@ contract EncodeExtraArgsOffchain {
         extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, finalityConfig);
     }
 
+    /// @notice Returns `FinalityCodec._encodeBlockDepthAndSafeFlag(blockDepth)` — **wait-for-safe** plus optional depth in the lower 16 bits.
+    /// @dev Per `FinalityCodec`, this encoding is for **allowed** finality (e.g. token pool `setAllowedFinalityConfig`, receiver policy),
+    ///      not for **requested** `requestedFinalityConfig` in sender ExtraArgsV3 (requested finality must be a single mode).
+    function encodeAllowedFinalityBlockDepthAndSafeFlag(uint16 blockDepth) public pure returns (bytes4) {
+        return FinalityCodec._encodeBlockDepthAndSafeFlag(blockDepth);
+    }
+
     /// @notice Get the NO_EXECUTION_ADDRESS for manual execution.
     /// @return The address that signals no automatic execution.
     function getNoExecutionAddress() public pure returns (address) {

--- a/script/examples/Example06.s.sol
+++ b/script/examples/Example06.s.sol
@@ -5,8 +5,8 @@ import {Script, console2} from "forge-std/Script.sol";
 
 import {EncodeExtraArgsOffchain} from "../EncodeExtraArgsOffchain.s.sol";
 
-import {FactoryBurnMintERC20} from
-    "@chainlink/contracts-ccip/contracts/tokenAdminRegistry/TokenPoolFactory/FactoryBurnMintERC20.sol";
+import {BaseERC20} from "@chainlink/contracts-ccip/contracts/tokens/BaseERC20.sol";
+import {CrossChainToken} from "@chainlink/contracts-ccip/contracts/tokens/CrossChainToken.sol";
 import {BurnMintTokenPool} from "@chainlink/contracts-ccip/contracts/pools/BurnMintTokenPool.sol";
 import {TokenPool} from "@chainlink/contracts-ccip/contracts/pools/TokenPool.sol";
 import {ITokenAdminRegistry} from "@chainlink/contracts-ccip/contracts/interfaces/ITokenAdminRegistry.sol";
@@ -34,7 +34,7 @@ contract DeployCCTBurnMintTokenAndPool is Script {
         require(armProxy != address(0), "armProxy cannot be zero");
         require(router != address(0), "router cannot be zero");
 
-        console2.log("[INFO] Example06 (CCT 01): Deploy BurnMint token + BurnMint pool");
+        console2.log("[INFO] Example06 (CCT 01): Deploy CrossChainToken + BurnMint pool");
         console2.log("[INFO] Source chain ID:", block.chainid);
         console2.log("[INFO] TokenAdminRegistry:", tokenAdminRegistry);
         console2.log("[INFO] RegistryModuleOwnerCustom:", registryModuleOwnerCustom);
@@ -49,9 +49,17 @@ contract DeployCCTBurnMintTokenAndPool is Script {
         vm.startBroadcast();
         (, address broadcaster,) = vm.readCallers();
 
-        FactoryBurnMintERC20 tokenContract = new FactoryBurnMintERC20(
-            TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, TOKEN_MAX_SUPPLY, TOKEN_PREMINT, broadcaster
-        );
+        BaseERC20.ConstructorParams memory tokenParams = BaseERC20.ConstructorParams({
+            name: TOKEN_NAME,
+            symbol: TOKEN_SYMBOL,
+            maxSupply: TOKEN_MAX_SUPPLY,
+            preMint: TOKEN_PREMINT,
+            preMintRecipient: broadcaster,
+            decimals: TOKEN_DECIMALS,
+            ccipAdmin: broadcaster
+        });
+        CrossChainToken tokenContract = new CrossChainToken(tokenParams, broadcaster, broadcaster);
+
         BurnMintTokenPool poolContract = new BurnMintTokenPool(
             IBurnMintERC20(address(tokenContract)),
             TOKEN_DECIMALS,
@@ -63,8 +71,8 @@ contract DeployCCTBurnMintTokenAndPool is Script {
         // Token pool needs mint and burn roles on the local token.
         tokenContract.grantMintAndBurnRoles(address(poolContract));
 
-        // Register token admin and attach pool in TokenAdminRegistry.
-        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaOwner(address(tokenContract));
+        // Register token admin and attach pool in TokenAdminRegistry (CrossChainToken uses getCCIPAdmin, not owner()).
+        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaGetCCIPAdmin(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).acceptAdminRole(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).setPool(address(tokenContract), address(poolContract));
 
@@ -73,7 +81,7 @@ contract DeployCCTBurnMintTokenAndPool is Script {
         token = address(tokenContract);
         pool = address(poolContract);
 
-        console2.log("[RESULT] Local CCT BurnMint token deployed:", token);
+        console2.log("[RESULT] Local CrossChainToken deployed:", token);
         console2.log("[RESULT] Local CCT BurnMint pool deployed:", pool);
         console2.log("[WARN] Remote chain configuration is not done yet.");
         console2.log("[WARN] Run Example06.run on both chains to link pools and tokens.");
@@ -131,39 +139,36 @@ contract Example06 is Script {
     }
 }
 
-contract Example06SetPoolMinBlockConfirmations is Script {
-    function run(address localPool, uint16 minBlockConfirmations) external returns (uint16 updatedMinBlockConfirmations) {
+/// @notice Sets `TokenPool` allowed finality (`FinalityCodec` bytes4). Use `FinalityCodec._encodeBlockDepth(depth)` for a depth-only policy; `bytes4(0)` waits for full finality.
+contract Example06SetPoolAllowedFinalityConfig is Script {
+    function run(address localPool, bytes4 allowedFinality) external returns (bytes4 updatedAllowedFinality) {
         require(localPool != address(0), "localPool cannot be zero");
 
-        uint16 previousMinBlockConfirmations = TokenPool(localPool).getMinBlockConfirmations();
-
-        console2.log("[INFO] Example06 (CCT 01): Set pool min block confirmations");
+        console2.log("[INFO] Example06 (CCT 01): Set pool allowed finality config");
         console2.log("[INFO] Source chain ID:", block.chainid);
         console2.log("[INFO] Local pool:", localPool);
-        console2.log("[INFO] Previous min block confirmations:", previousMinBlockConfirmations);
-        console2.log("[INFO] New min block confirmations:", minBlockConfirmations);
+        console2.logBytes4(TokenPool(localPool).getAllowedFinalityConfig());
+        console2.logBytes4(allowedFinality);
 
         vm.startBroadcast();
-        TokenPool(localPool).setMinBlockConfirmations(minBlockConfirmations);
+        TokenPool(localPool).setAllowedFinalityConfig(allowedFinality);
         vm.stopBroadcast();
 
-        updatedMinBlockConfirmations = TokenPool(localPool).getMinBlockConfirmations();
-        console2.log("[RESULT] Updated min block confirmations:", updatedMinBlockConfirmations);
+        updatedAllowedFinality = TokenPool(localPool).getAllowedFinalityConfig();
+        console2.logBytes4(updatedAllowedFinality);
     }
 }
 
-contract Example06GetPoolMinBlockConfirmations is Script {
-    function run(
-        address localPool
-    ) external view returns (uint16 minBlockConfirmations) {
+contract Example06GetPoolAllowedFinalityConfig is Script {
+    function run(address localPool) external view returns (bytes4 allowedFinality) {
         require(localPool != address(0), "localPool cannot be zero");
 
-        minBlockConfirmations = TokenPool(localPool).getMinBlockConfirmations();
+        allowedFinality = TokenPool(localPool).getAllowedFinalityConfig();
 
-        console2.log("[INFO] Example06 (CCT 01): Read pool min block confirmations");
+        console2.log("[INFO] Example06 (CCT 01): Read pool allowed finality config");
         console2.log("[INFO] Source chain ID:", block.chainid);
         console2.log("[INFO] Local pool:", localPool);
-        console2.log("[RESULT] Min block confirmations:", minBlockConfirmations);
+        console2.logBytes4(allowedFinality);
     }
 }
 

--- a/script/examples/Example07.s.sol
+++ b/script/examples/Example07.s.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.26;
 
 import {Script, console2} from "forge-std/Script.sol";
 
-import {FactoryBurnMintERC20} from
-    "@chainlink/contracts-ccip/contracts/tokenAdminRegistry/TokenPoolFactory/FactoryBurnMintERC20.sol";
+import {BaseERC20} from "@chainlink/contracts-ccip/contracts/tokens/BaseERC20.sol";
+import {CrossChainToken} from "@chainlink/contracts-ccip/contracts/tokens/CrossChainToken.sol";
 import {LockReleaseTokenPool} from "@chainlink/contracts-ccip/contracts/pools/LockReleaseTokenPool.sol";
 import {ERC20LockBox} from "@chainlink/contracts-ccip/contracts/pools/ERC20LockBox.sol";
 import {TokenPool} from "@chainlink/contracts-ccip/contracts/pools/TokenPool.sol";
@@ -47,9 +47,16 @@ contract DeployCCTLockReleaseTokenAndPool is Script {
         vm.startBroadcast();
         (, address broadcaster,) = vm.readCallers();
 
-        FactoryBurnMintERC20 tokenContract = new FactoryBurnMintERC20(
-            TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, TOKEN_MAX_SUPPLY, TOKEN_PREMINT, broadcaster
-        );
+        BaseERC20.ConstructorParams memory tokenParams = BaseERC20.ConstructorParams({
+            name: TOKEN_NAME,
+            symbol: TOKEN_SYMBOL,
+            maxSupply: TOKEN_MAX_SUPPLY,
+            preMint: TOKEN_PREMINT,
+            preMintRecipient: broadcaster,
+            decimals: TOKEN_DECIMALS,
+            ccipAdmin: broadcaster
+        });
+        CrossChainToken tokenContract = new CrossChainToken(tokenParams, broadcaster, broadcaster);
         ERC20LockBox lockBoxContract = new ERC20LockBox(address(tokenContract));
         LockReleaseTokenPool poolContract = new LockReleaseTokenPool(
             IERC20(address(tokenContract)),
@@ -66,8 +73,8 @@ contract DeployCCTLockReleaseTokenAndPool is Script {
             AuthorizedCallers.AuthorizedCallerArgs({addedCallers: addedCallers, removedCallers: new address[](0)})
         );
 
-        // Register token admin and attach pool in TokenAdminRegistry.
-        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaOwner(address(tokenContract));
+        // Register token admin and attach pool in TokenAdminRegistry (CrossChainToken uses getCCIPAdmin, not owner()).
+        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaGetCCIPAdmin(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).acceptAdminRole(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).setPool(address(tokenContract), address(poolContract));
 
@@ -77,7 +84,7 @@ contract DeployCCTLockReleaseTokenAndPool is Script {
         lockBox = address(lockBoxContract);
         pool = address(poolContract);
 
-        console2.log("[RESULT] Local CCT LockRelease token deployed:", token);
+        console2.log("[RESULT] Local CrossChainToken (LockRelease flow) deployed:", token);
         console2.log("[RESULT] Local CCT lock box deployed:", lockBox);
         console2.log("[RESULT] Local CCT LockRelease pool deployed:", pool);
         console2.log("[WARN] Remote chain configuration is not done yet.");

--- a/script/examples/Example08.s.sol
+++ b/script/examples/Example08.s.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.26;
 
 import {Script, console2} from "forge-std/Script.sol";
 
-import {FactoryBurnMintERC20} from
-    "@chainlink/contracts-ccip/contracts/tokenAdminRegistry/TokenPoolFactory/FactoryBurnMintERC20.sol";
+import {BaseERC20} from "@chainlink/contracts-ccip/contracts/tokens/BaseERC20.sol";
+import {CrossChainToken} from "@chainlink/contracts-ccip/contracts/tokens/CrossChainToken.sol";
 import {AdvancedPoolHooks} from "@chainlink/contracts-ccip/contracts/pools/AdvancedPoolHooks.sol";
 import {BurnMintTokenPool} from "@chainlink/contracts-ccip/contracts/pools/BurnMintTokenPool.sol";
 import {TokenPool} from "@chainlink/contracts-ccip/contracts/pools/TokenPool.sol";
@@ -37,7 +37,7 @@ contract DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook is Script {
         require(armProxy != address(0), "armProxy cannot be zero");
         require(router != address(0), "router cannot be zero");
 
-        console2.log("[INFO] Example08 (CCT 03): Deploy BurnMint token + AdvancedPoolHooks + BurnMint pool");
+        console2.log("[INFO] Example08 (CCT 03): Deploy CrossChainToken + AdvancedPoolHooks + BurnMint pool");
         console2.log("[INFO] Source chain ID:", block.chainid);
         console2.log("[INFO] TokenAdminRegistry:", tokenAdminRegistry);
         console2.log("[INFO] RegistryModuleOwnerCustom:", registryModuleOwnerCustom);
@@ -64,9 +64,16 @@ contract DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook is Script {
             authorizedCallers // authorized callers disabled
         );
 
-        FactoryBurnMintERC20 tokenContract = new FactoryBurnMintERC20(
-            TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, TOKEN_MAX_SUPPLY, TOKEN_PREMINT, broadcaster
-        );
+        BaseERC20.ConstructorParams memory tokenParams = BaseERC20.ConstructorParams({
+            name: TOKEN_NAME,
+            symbol: TOKEN_SYMBOL,
+            maxSupply: TOKEN_MAX_SUPPLY,
+            preMint: TOKEN_PREMINT,
+            preMintRecipient: broadcaster,
+            decimals: TOKEN_DECIMALS,
+            ccipAdmin: broadcaster
+        });
+        CrossChainToken tokenContract = new CrossChainToken(tokenParams, broadcaster, broadcaster);
         BurnMintTokenPool poolContract = new BurnMintTokenPool(
             IBurnMintERC20(address(tokenContract)), TOKEN_DECIMALS, address(advancedPoolHooks), armProxy, router
         );
@@ -81,8 +88,8 @@ contract DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook is Script {
         // Token pool needs mint and burn roles on the local token.
         tokenContract.grantMintAndBurnRoles(address(poolContract));
 
-        // Register token admin and attach pool in TokenAdminRegistry.
-        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaOwner(address(tokenContract));
+        // Register token admin and attach pool in TokenAdminRegistry (CrossChainToken uses getCCIPAdmin, not owner()).
+        RegistryModuleOwnerCustom(registryModuleOwnerCustom).registerAdminViaGetCCIPAdmin(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).acceptAdminRole(address(tokenContract));
         ITokenAdminRegistry(tokenAdminRegistry).setPool(address(tokenContract), address(poolContract));
 
@@ -92,7 +99,7 @@ contract DeployCCTBurnMintTokenAndPoolWithAdvancedPoolHook is Script {
         advancedPoolHook = address(advancedPoolHooks);
         pool = address(poolContract);
 
-        console2.log("[RESULT] Local CCT BurnMint token deployed:", token);
+        console2.log("[RESULT] Local CrossChainToken deployed:", token);
         console2.log("[RESULT] Local AdvancedPoolHooks deployed:", advancedPoolHook);
         console2.log("[RESULT] Local CCT BurnMint pool deployed:", pool);
         console2.log("[RESULT] Authorized caller added to hook:", pool);

--- a/src/BasicMessageReceiverWithCCVs.sol
+++ b/src/BasicMessageReceiverWithCCVs.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import {BasicMessageReceiver} from "./BasicMessageReceiver.sol";
 
+import {FinalityCodec} from "@chainlink/contracts-ccip/contracts/libraries/FinalityCodec.sol";
 import {Ownable, Ownable2Step} from "@openzeppelin/contracts@5.3.0/access/Ownable2Step.sol";
 
 /**
@@ -51,8 +52,9 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
         emit MinBlockDepthSet(sourceChainSelector, minBlockDepth);
     }
 
-    /// @dev Override getCCVsAndMinBlockDepth
-    function getCCVsAndMinBlockDepth(
+    /// @notice Returns CCV config and allowed finality for a source chain (see `CCIPReceiver.getCCVsAndFinalityConfig`).
+    /// @dev Maps stored min block depth to `FinalityCodec` encoding (0 depth => wait for full finality).
+    function getCCVsAndFinalityConfig(
         uint64 sourceChainSelector,
         bytes calldata /*sender*/
     )
@@ -63,12 +65,13 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
             address[] memory requiredCCVs,
             address[] memory optionalCCVs,
             uint8 optionalThreshold,
-            uint16 minBlockDepth
+            bytes4 allowedFinalityConfig
         )
     {
         CCVConfig memory config = s_ccvConfigs[sourceChainSelector];
-        return
-            (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, s_minBlockDepths[sourceChainSelector]);
+        uint16 minBlockDepth = s_minBlockDepths[sourceChainSelector];
+        allowedFinalityConfig = FinalityCodec._encodeBlockDepth(minBlockDepth);
+        return (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, allowedFinalityConfig);
     }
 
     /// @notice Set CCV configurations for source chains.


### PR DESCRIPTION
## Summary

This PR updates the Foundry CCIP starter kit to **chainlink-ccip 2.0 beta**, switches CCT example deployments to **`CrossChainToken`**, and aligns scripts and docs with the **FinalityCodec** / **`bytes4` finality** model (ExtraArgs V3, receivers, token pools, and executor). It also refreshes the **Example 01** book chapter for the new executor API.

**Commits (newest → oldest in branch):**
1. `docs(book): update Example 01 optional step 2for Executor allowed finality (FinalityCodec)` — book-only; replace deprecated `getMinBlockConfirmations()` with `getAllowedFinalityConfig()` + `cast call` and FinalityCodec context.
2. `Bumped chainlink-ccip dependency to 2.0-beta commit` — dependency / submodule bump.
3. `feat(cct): deploy CrossChainToken in CCT examples; align with FinalityCodec CCIP APIs` — main code + book changes (see below).

---

## What changed

### CCT (Examples 06–08)

- Deploy **`CrossChainToken`** using **`BaseERC20.ConstructorParams`** (broadcaster = pre-mint recipient, CCIP admin, burn/mint admin, default admin).
- Register the token with **`RegistryModuleOwnerCustom.registerAdminViaGetCCIPAdmin`** (not `registerAdminViaOwner`).
- **Example 06:** pool helpers use **`getAllowedFinalityConfig` / `setAllowedFinalityConfig`** on **`TokenPool`** (replaces `getMinBlockConfirmations` / `setMinBlockConfirmations`); scripts renamed to **`Example06SetPoolAllowedFinalityConfig`** / **`Example06GetPoolAllowedFinalityConfig`**.

### Extra args & receiver

- **`script/EncodeExtraArgsOffchain.s.sol`:** Generic V3 uses **`requestedFinalityConfig`**; **`encodeV3Basic`** uses **`FinalityCodec._encodeBlockDepth`** + **`ExtraArgsCodec._getBasicEncodedExtraArgsV3`**.
- **`src/BasicMessageReceiverWithCCVs.sol`:** **`getCCVsAndFinalityConfig`** replaces **`getCCVsAndMinBlockDepth`**, mapping stored min depth via **`FinalityCodec._encodeBlockDepth`**.

### CCT send scripts

- **`SendCCTTokenWithExtraArgsV3*`** still call **`encodeV3Basic`**; encoding path is updated under the hood.

### Docs (book)

- Examples **06–08** and **`ccip-sdk-ccip-send`**: CrossChainToken, `registerAdminViaGetCCIPAdmin`, **`getCCVsAndFinalityConfig`** wording.
- **Example 01:** optional executor check documents **`getAllowedFinalityConfig()(bytes4)`** and `cast call` (no `getMinBlockConfirmations`).
